### PR TITLE
Allow user to explicitly set port while starting server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ltracker-backend
 A simple node js backend for ltacker, that keeps track of money lending
+
+# Start Server
+1. Install a file watcher utility tool (ex: nodemon) to automatically restart the server on file changes in development.
+
+  * Install nodemon: `npm i -g nodemon`
+
+2. Start server using `[PORT=8081] nodemon start src/app.js`

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    port:3000,
+    port: process.env.PORT || 3000,
 
     db : {
         name : 'ltracker',


### PR DESCRIPTION
PORT option can be given while starting the server.
If PORT is not set explicitly, server will be reachable at port 3000. 